### PR TITLE
Added puppet to Dockerfiles and the README

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -107,6 +107,12 @@ COPY bundler/Gemfile \
      /home/dependabot/dependabot-core/bundler/
 RUN cd bundler && bundle install
 
+RUN mkdir -p /home/dependabot/dependabot-core/puppet
+COPY puppet/Gemfile \
+     puppet/dependabot-puppet.gemspec \
+     /home/dependabot/dependabot-core/puppet/
+RUN cd puppet && bundle install
+
 RUN mkdir -p /home/dependabot/dependabot-core/omnibus
 COPY omnibus/Gemfile \
      omnibus/dependabot-omnibus.gemspec \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -83,6 +83,10 @@ RUN mkdir -p /home/dependabot/dependabot-core/bundler
 COPY bundler/Gemfile bundler/dependabot-bundler.gemspec /home/dependabot/dependabot-core/bundler/
 RUN cd bundler && bundle install
 
+RUN mkdir -p /home/dependabot/dependabot-core/puppet
+COPY puppet/Gemfile puppet/dependabot-puppet.gemspec /home/dependabot/dependabot-core/puppet/
+RUN cd puppet && bundle install
+
 RUN mkdir -p /home/dependabot/dependabot-core/omnibus
 COPY omnibus/Gemfile omnibus/dependabot-omnibus.gemspec /home/dependabot/dependabot-core/omnibus/
 RUN cd omnibus && bundle install

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ should give you the tools you need. A reference implementation is available
 
 Dependabot Core is a collection of packages for automating dependency updating
 in Ruby, JavaScript, Python, PHP, Elixir, Elm, Go, Rust, Java and
-.NET. It can also update git submodules, Docker files and Terraform files.
+.NET. It can also update git submodules, Docker files Terraform files, and
+Puppet modules listed in a Puppetfile.
 Highlights include:
 
 - Logic to check for the latest version of a dependency *that's resolvable given


### PR DESCRIPTION
With these changes I was able to build `Dockerfile.ci` and was able to run `bin/docker-dev-shell` which builds `Dockerfile.development`. The commit also includes adding Puppet to the list of things talked about in `README.md`.

**What works**

```
~/dependabot-core(f8ce328*) » docker build -f Dockerfile.ci -t dependabot/dependabot-ci-puppet .

~/dependabot-core(f8ce328*) » docker run -it --rm dependabot/dependabot-ci-puppet bin/dry-run.rb puppet jpogran/control-repo
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.5-compliant syntax, but you are running 2.6.2.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> fetching dependency files
=> parsing dependency files
=> updating 2 dependencies

=== puppetlabs-dsc (1.4.0)
 => checking for updates
 => requirements to unlock own
 => updating to 1.9.3

    ± Puppetfile
    ~~~
    8c8
    < mod "puppetlabs/dsc", '1.4.0'
    ---
    > mod "puppetlabs/dsc", '1.9.3'
    ~~~

=== puppet-windowsfeature (2.0.0)
 => checking for updates
 => requirements to unlock own
 => updating to 3.2.2

    ± Puppetfile
    ~~~
    10c10
    < mod "puppet/windowsfeature", '2.0.0'
    ---
    > mod "puppet/windowsfeature", '3.2.2'
    ~~~
```

**What doesn't work**

```
~/dependabot-core(f8ce328*) » bin/docker-dev-shell                                                              vagrant@localhost
 > image dependabot/dependabot-core-development already exists
=> running docker development shell
[dependabot-core-dev] ~/dependabot-core $ cd omnibus && bundle install && cd -
Using rake 12.3.3
Using public_suffix 4.0.1
Using addressable 2.7.0
Using ast 2.4.0
Using aws-eventstream 1.0.3
Using aws-partitions 1.220.0
Using aws-sigv4 1.1.0
Using jmespath 1.4.0
Using aws-sdk-core 3.68.1
Using aws-sdk-ecr 1.20.0
Using bundler 1.17.3
Using byebug 11.0.1
Using citrus 3.0.2
Using safe_yaml 1.0.5
Using crack 0.4.3
Using http-accept 1.7.0
Using unf_ext 0.0.7.6
Using unf 0.1.4
Using domain_name 0.5.20190701
Using http-cookie 1.0.3
Using mime-types-data 3.2019.0904
Using mime-types 3.3
Using netrc 0.11.0
Using rest-client 2.1.0
Using docker_registry2 1.8.0
Using excon 0.67.0
Using multi_xml 0.6.0
Using httparty 0.17.1
Using unicode-display_width 1.6.0
Using terminal-table 1.8.0
Using gitlab 4.12.0
Using mini_portile2 2.4.0
Using gpgme 2.0.19
Using nokogiri 1.10.4
Using multipart-post 2.1.1
Using faraday 0.16.2
Using sawyer 0.8.2
Using octokit 4.14.0
Using pandoc-ruby 2.0.2
Using parseconfig 1.0.8
Using parser 2.6.5.0
Using toml-rb 1.1.2
Using dependabot-common 0.111.37 from source at `../common`
Using dependabot-bundler 0.111.37 from source at `../bundler`
Using dependabot-cargo 0.111.37 from source at `../cargo`
Using dependabot-composer 0.111.37 from source at `../composer`
Using dependabot-dep 0.111.37 from source at `../dep`
Using dependabot-docker 0.111.37 from source at `../docker`
Using dependabot-elm 0.111.37 from source at `../elm`
Using dependabot-git_submodules 0.111.37 from source at `../git_submodules`
Using dependabot-go_modules 0.111.37 from source at `../go_modules`
Using dependabot-gradle 0.111.37 from source at `../gradle`
Using dependabot-hex 0.111.37 from source at `../hex`
Using dependabot-maven 0.111.37 from source at `../maven`
Using dependabot-npm_and_yarn 0.111.37 from source at `../npm_and_yarn`
Using dependabot-nuget 0.111.37 from source at `../nuget`
Using dependabot-puppet 0.111.37 from source at `../puppet`
Using dependabot-python 0.111.37 from source at `../python`
Using dependabot-terraform 0.111.37 from source at `../terraform`
Using dependabot-omnibus 0.111.37 from source at `.`
Using diff-lcs 1.3
Using hashdiff 1.0.0
Using jaro_winkler 1.5.3
Using parallel 1.17.0
Using rainbow 3.0.0
Using rspec-support 3.8.3
Using rspec-core 3.8.2
Using rspec-expectations 3.8.5
Using rspec-mocks 3.8.2
Using rspec 3.8.0
Using rspec-its 1.3.0
Using rspec_junit_formatter 0.4.1
Using ruby-progressbar 1.10.1
Using rubocop 0.75.0
Using vcr 5.0.0
Using webmock 3.7.6
Bundle complete! 26 Gemfile dependencies, 76 gems now installed.
Bundled gems are installed into `/home/dependabot/.bundle`
/home/dependabot/dependabot-core

[dependabot-core-dev] ~/dependabot-core $ bin/dry-run.rb puppet jpogran/control-repo
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.5-compliant syntax, but you are running 2.6.2.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Traceback (most recent call last):
	1: from bin/dry-run.rb:82:in `<main>'
bin/dry-run.rb:82:in `require': cannot load such file -- dependabot/puppet (LoadError)
```